### PR TITLE
Fix MathJax display delimiter handling

### DIFF
--- a/_includes/custom-head.html
+++ b/_includes/custom-head.html
@@ -2,7 +2,7 @@
   window.MathJax = {
     tex: {
       inlineMath: [["\\(", "\\)"]],
-      displayMath: [["$$", "$$"]],
+      displayMath: [["$$", "$$"], ["\\[", "\\]"]],
       processEscapes: true
     },
     options: {


### PR DESCRIPTION
## Summary
- update MathJax config to recognize both $$ ...  and \\[ ... \\] display math delimiters

## Why
The equations in the eval post were rendering as raw TeX because the page output used \\[ ... \\] delimiters, but the MathJax config only handled $$ ... .