### PR TITLE
Inject MathJax via head include

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,24 @@
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  {%- seo -%}
+  <link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}">
+  {%- feed_meta -%}
+  <script>
+    window.MathJax = {
+      tex: {
+        inlineMath: [["\\(", "\\)"]],
+        displayMath: [["$$", "$$"], ["\\[", "\\]"]],
+        processEscapes: true
+      },
+      options: {
+        skipHtmlTags: ["script", "noscript", "style", "textarea", "pre", "code"]
+      }
+    };
+  </script>
+  <script
+    id="MathJax-script"
+    async
+    src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+</head>


### PR DESCRIPTION
## Summary
- override Minima's head.html include in the repo
- load MathJax directly from the published page head
- support both $$ ...  and \\[ ... \\] display delimiters

## Why
The previous attempts updated _includes/custom-head.html, but the live deployed HTML never included that file. The published page had no MathJax script tag at all, so the equations rendered as raw TeX. This fix injects the script through _includes/head.html, which the deployed site actually uses.