### PR TITLE
Render eval formulas without MathJax

### DIFF
--- a/_posts/2026-03-05-how-to-do-evals.md
+++ b/_posts/2026-03-05-how-to-do-evals.md
@@ -22,17 +22,17 @@ I think evals serve **two purposes**.
 
 The cleanest way I know to frame this is:
 
-$$
-Q = \mathbb{E}_{x \sim P_{\mathrm{real}}}[\mathrm{score}(f_{\mathrm{prod}}(x))]
-$$
+<div class="equation">
+  Q = E<sub>x ~ P<sub>real</sub></sub>[score(f<sub>prod</sub>(x))]
+</div>
 
 This is the true product quality. It is the expected score of your production system over real user inputs.
 
 What eval gives you is only an estimate:
 
-$$
-\hat{Q}_n = \frac{1}{n} \sum_i \mathrm{score}(f_{\mathrm{eval}}(x_i))
-$$
+<div class="equation">
+  Q̂<sub>n</sub> = (1 / n) Σ<sub>i</sub> score(f<sub>eval</sub>(x<sub>i</sub>))
+</div>
 
 If you want that estimate to mean anything, **three conditions** have to hold.
 

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -133,6 +133,19 @@ code {
   background: var(--accent-soft);
 }
 
+.equation {
+  margin: 1.25rem 0 1.4rem;
+  padding: 1rem 1.2rem;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--surface-strong);
+  box-shadow: var(--shadow);
+  font-size: 1.2rem;
+  line-height: 1.5;
+  letter-spacing: -0.01em;
+}
+
 .site-footer {
   border-top: 1px solid var(--border);
   background: #f1ece0;
@@ -163,5 +176,9 @@ code {
 
   .home > p {
     font-size: 1.02rem;
+  }
+
+  .equation {
+    font-size: 1.05rem;
   }
 }


### PR DESCRIPTION
## Summary
- replace the two MathJax-based equations in the eval post with HTML-rendered equations
- add a small .equation style so they render consistently without client-side math JS

## Why
The live page now includes MathJax, but the equations still do not render reliably in the browser. Since there are only two formulas and both are simple, rendering them directly in HTML is the most reliable fix for GitHub Pages.